### PR TITLE
修复 引入模块名称大小写不一致导致的异常报错

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { indexStore } from '@/stores'
-import { useDisplay } from 'Vuetify'
+import { useDisplay } from 'vuetify'
 
 const { isLogin } = indexStore()
 const { xs } = useDisplay()

--- a/frontend/src/views/user/dialog/loginLogs.vue
+++ b/frontend/src/views/user/dialog/loginLogs.vue
@@ -4,7 +4,7 @@ import { indexStore } from '@/stores'
 import _ from 'lodash'
 import { getUserLoginLogsApi } from '@/apis/user'
 import type { LoginIP, SortItem } from '@/types'
-import { useDisplay } from 'Vuetify'
+import { useDisplay } from 'vuetify'
 
 const open = ref(false)
 const openDialog = () => {

--- a/frontend/vite.config.mts
+++ b/frontend/vite.config.mts
@@ -2,7 +2,7 @@ import { fileURLToPath, URL } from 'node:url'
 
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
-import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
+import vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -22,7 +22,7 @@ export default defineConfig({
     vue({
       template: { transformAssetUrls }
     }),
-    Vuetify({
+    vuetify({
       autoImport: true,
       styles: {
         configFile: 'src/styles/settings.scss'


### PR DESCRIPTION
import中的模块名称大小写与package.json中的不一致会导致如下报错:
```log
[ERROR] Two output files share the same path but have different contents: node_modules\.vite\deps_temp_10545c83\Vuetify.js

D:\Git\NyancyAccount\frontend\node_modules\.pnpm\esbuild@0.19.12\node_modules\esbuild\lib\main.js:1651
  let error = new Error(text);
              ^

Error: Build failed with 1 error:
error: Two output files share the same path but have different contents: node_modules\.vite\deps_temp_10545c83\Vuetify.js
    at failureErrorWithLog (D:\Git\NyancyAccount\frontend\node_modules\.pnpm\esbuild@0.19.12\node_modules\esbuild\lib\main.js:1651:15)
    at D:\Git\NyancyAccount\frontend\node_modules\.pnpm\esbuild@0.19.12\node_modules\esbuild\lib\main.js:1059:25
    at D:\Git\NyancyAccount\frontend\node_modules\.pnpm\esbuild@0.19.12\node_modules\esbuild\lib\main.js:1527:9
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5) {
  errors: [Getter/Setter],
  warnings: [Getter/Setter]
}

Node.js v22.11.0
 ELIFECYCLE  Command failed with exit code 1.
```
统一小写vuetify可解决问题